### PR TITLE
feat: add ingredient segmentation CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,18 @@ npx gutty build-index
 npx gutty recipe-analyze --image Gutty_Data/000001/img1.jpg --out ./analysis.json
 ```
 
+### Ingredient segmentation (zero-train)
+```bash
+# build region index from FoodSeg103 / FoodInsSeg crops
+npx gutty seg-index --foodseg103 /path/to/FoodSeg103/crops --foodinsseg /path/to/FoodInsSeg/crops
+
+# extract ingredient masks from a photo
+npx gutty seg-extract --image sample.jpg --labels "tomato,lettuce,bread" --out ./tmp/masks
+
+# retrieve nearest labeled ingredients for each mask
+npx gutty seg-retrieve --masks ./tmp/masks --topk 5 --out ./tmp/segments.json
+```
+
 ## Providers & fallbacks
 Order: **Vertex → Replicate → Fal**
 

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -18,6 +18,9 @@ import healthEmbed from "../src/cli/health-embed";
 import healthBuildIndex from "../src/cli/health-build-index";
 import healthQuery from "../src/cli/health-query";
 import healthAnnotate from "../src/cli/health-annotate";
+import segIndex from "../src/cli/seg-index";
+import segExtract from "../src/cli/seg-extract";
+import segRetrieve from "../src/cli/seg-retrieve";
 
 const program = new Command();
 program.name("gutty").description("Photo → Recipe → Calories (standalone CLI)");
@@ -36,6 +39,9 @@ program.addCommand(healthEmbed);
 program.addCommand(healthBuildIndex);
 program.addCommand(healthQuery);
 program.addCommand(healthAnnotate);
+program.addCommand(segIndex);
+program.addCommand(segExtract);
+program.addCommand(segRetrieve);
 program.addCommand(validate);
 program.addCommand(reset);
 

--- a/src/cli/seg-extract.test.ts
+++ b/src/cli/seg-extract.test.ts
@@ -1,0 +1,31 @@
+import path from 'path';
+import os from 'os';
+import { promises as fs } from 'fs';
+import { expect, test, vi } from 'vitest';
+
+const { segMock } = vi.hoisted(() => {
+  return {
+    segMock: vi.fn()
+      .mockRejectedValueOnce(new Error('fail'))
+      .mockResolvedValue([{ label: 'tomato', mask: Buffer.from('m') }]),
+  };
+});
+
+vi.mock('../providers/segment', () => ({
+  groundedSam2: segMock,
+}));
+
+import command from './seg-extract';
+
+test('extracts masks with retry', async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'gutty-'));
+  const img = path.join(tmp, 'img.jpg');
+  await fs.writeFile(img, '');
+  const out = path.join(tmp, 'out');
+
+  await command.parseAsync(['node', 'test', '--image', img, '--labels', 'tomato', '--out', out], { from: 'node' });
+
+  expect(segMock).toHaveBeenCalledTimes(2);
+  const files = await fs.readdir(out);
+  expect(files[0]).toMatch(/tomato_0\.png/);
+});

--- a/src/cli/seg-extract.ts
+++ b/src/cli/seg-extract.ts
@@ -1,0 +1,26 @@
+import { Command } from "commander";
+import { groundedSam2 } from "../providers/segment";
+import { withRetry } from "../util/retry";
+import { promises as fs } from "fs";
+import path from "path";
+
+export default new Command("seg-extract")
+  .requiredOption("--image <path>")
+  .option("--labels <list>", "Comma separated labels", "")
+  .option("--out <dir>", "./tmp/seg")
+  .action(async (opts) => {
+    const prompts = String(opts.labels || "").split(",").map((s:string)=>s.trim()).filter(Boolean);
+    try {
+      const segs = await withRetry(() => groundedSam2({ path: opts.image }, prompts));
+      await fs.mkdir(opts.out, { recursive: true });
+      let i = 0;
+      for (const s of segs) {
+        const file = path.join(opts.out, `${s.label.replace(/\s+/g,"_")}_${i}.png`);
+        await fs.writeFile(file, s.mask);
+        i++;
+      }
+      console.log(`Wrote ${i} masks to ${opts.out}`);
+    } catch (err:any) {
+      console.error(`Segmentation failed: ${err?.message || err}`);
+    }
+  });

--- a/src/cli/seg-index.test.ts
+++ b/src/cli/seg-index.test.ts
@@ -1,0 +1,44 @@
+import path from 'path';
+import os from 'os';
+import { promises as fs } from 'fs';
+import { expect, test, vi } from 'vitest';
+
+const { upsertMock, createIndexMock, embedMock } = vi.hoisted(() => {
+  return {
+    upsertMock: vi.fn(),
+    createIndexMock: vi.fn(),
+    embedMock: vi.fn()
+      .mockRejectedValueOnce(new Error('fail'))
+      .mockResolvedValue(new Float32Array([1,2])),
+  };
+});
+
+vi.mock('../index/lancedb', () => ({
+  upsertSegments: upsertMock,
+  createIndex: createIndexMock,
+}));
+vi.mock('../providers/selector', () => ({
+  withFallback: async (fn:any) => fn({ imageEmbed: embedMock })
+}));
+vi.mock('../providers/availability', () => ({
+  requireEmbeddingsProvider: () => {},
+}));
+
+import command from './seg-index';
+
+test('indexes segments with retries and progress', async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'gutty-'));
+  const ds = path.join(tmp, 'label');
+  await fs.mkdir(ds, { recursive: true });
+  const img = path.join(ds, 'a.jpg');
+  await fs.writeFile(img, '');
+  const progress = path.join(tmp, 'prog.json');
+
+  await command.parseAsync(['node', 'test', '--foodseg103', tmp, '--progress', progress], { from:'node' });
+
+  expect(embedMock).toHaveBeenCalledTimes(2);
+  expect(upsertMock).toHaveBeenCalledTimes(1);
+  const prog = JSON.parse(await fs.readFile(progress, 'utf8'));
+  expect(prog.doneIds).toHaveProperty('foodseg103-a.jpg');
+  expect(createIndexMock).toHaveBeenCalled();
+});

--- a/src/cli/seg-index.ts
+++ b/src/cli/seg-index.ts
@@ -1,0 +1,63 @@
+import { Command } from "commander";
+import { withFallback } from "../providers/selector";
+import { requireEmbeddingsProvider } from "../providers/availability";
+import { upsertSegments, createIndex } from "../index/lancedb";
+import { CFG } from "../config";
+import { promises as fs } from "fs";
+import path from "path";
+import { withRetry } from "../util/retry";
+
+async function walk(dir:string): Promise<string[]> {
+  const out:string[] = [];
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  for (const e of entries) {
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) out.push(...await walk(p));
+    else if (/\.(jpg|jpeg|png)$/i.test(e.name)) out.push(p);
+  }
+  return out;
+}
+
+export default new Command("seg-index")
+  .option("--foodseg103 <dir>")
+  .option("--foodinsseg <dir>")
+  .option("--progress <path>", "Progress file", "./tmp/seg-index.progress.json")
+  .action(async (opts) => {
+    requireEmbeddingsProvider();
+    const datasets: {dir:string, source:string}[] = [];
+    if (opts.foodseg103) datasets.push({ dir: opts.foodseg103, source: "foodseg103" });
+    if (opts.foodinsseg) datasets.push({ dir: opts.foodinsseg, source: "foodinsseg" });
+    type Progress = { doneIds: Record<string, true> };
+    async function loadProgress(file:string): Promise<Progress>{
+      try { return JSON.parse(await fs.readFile(file, "utf8")); } catch { return { doneIds:{} }; }
+    }
+    async function saveProgress(file:string, data:Progress){
+      await fs.mkdir(path.dirname(file), { recursive: true });
+      await fs.writeFile(file, JSON.stringify(data, null, 2));
+    }
+
+    const prog = await loadProgress(opts.progress);
+    let processed = 0;
+
+    for (const ds of datasets) {
+      const files = await walk(ds.dir);
+      for (const f of files) {
+        const id = `${ds.source}-${path.basename(f)}`;
+        if (prog.doneIds[id]) continue;
+        const label = path.basename(path.dirname(f));
+        try {
+          const emb = await withRetry(() => withFallback(p => p.imageEmbed({ path: f })));
+          await withRetry(() => upsertSegments([{ id, source: ds.source, label, image_path: f, emb_clip_b32: Array.from(emb) }]));
+          prog.doneIds[id] = true;
+          processed++;
+          if (processed % 10 === 0) await saveProgress(opts.progress, prog);
+        } catch (err:any) {
+          console.warn(`Failed to index ${f}: ${err?.message || err}`);
+        }
+      }
+    }
+    await saveProgress(opts.progress, prog);
+    if (!processed) { console.log("No images indexed"); return; }
+    await createIndex(CFG.storage.segmentsTable, "emb_clip_b32");
+    console.log(`Indexed ${processed} segments`);
+  });

--- a/src/cli/seg-retrieve.test.ts
+++ b/src/cli/seg-retrieve.test.ts
@@ -1,0 +1,39 @@
+import path from 'path';
+import os from 'os';
+import { promises as fs } from 'fs';
+import { expect, test, vi } from 'vitest';
+
+const { annSearchMock, embedMock } = vi.hoisted(() => {
+  return {
+    annSearchMock: vi.fn().mockResolvedValue([{id:'x'}]),
+    embedMock: vi.fn()
+      .mockRejectedValueOnce(new Error('fail'))
+      .mockResolvedValue(new Float32Array([1,2])),
+  };
+});
+
+vi.mock('../index/lancedb', () => ({
+  annSearch: annSearchMock,
+}));
+vi.mock('../providers/selector', () => ({
+  withFallback: async (fn:any) => fn({ imageEmbed: embedMock })
+}));
+vi.mock('../providers/availability', () => ({
+  requireEmbeddingsProvider: () => {},
+}));
+
+import command from './seg-retrieve';
+
+test('retrieves segment matches with progress and retries', async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'gutty-'));
+  const img = path.join(tmp, 'mask.png');
+  await fs.writeFile(img, '');
+  const out = path.join(tmp, 'out.json');
+
+  await command.parseAsync(['node','test','--masks', tmp, '--out', out, '--progress', out], { from:'node' });
+
+  expect(embedMock).toHaveBeenCalledTimes(2);
+  expect(annSearchMock).toHaveBeenCalledTimes(1);
+  const res = JSON.parse(await fs.readFile(out, 'utf8'));
+  expect(res).toHaveProperty(img);
+});

--- a/src/cli/seg-retrieve.ts
+++ b/src/cli/seg-retrieve.ts
@@ -1,0 +1,48 @@
+import { Command } from "commander";
+import { withFallback } from "../providers/selector";
+import { requireEmbeddingsProvider } from "../providers/availability";
+import { annSearch } from "../index/lancedb";
+import { CFG } from "../config";
+import { promises as fs } from "fs";
+import path from "path";
+import { withRetry } from "../util/retry";
+
+async function walk(dir:string): Promise<string[]> {
+  const out:string[] = [];
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  for (const e of entries) {
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) out.push(...await walk(p));
+    else if (/\.(jpg|jpeg|png)$/i.test(e.name)) out.push(p);
+  }
+  return out;
+}
+
+export default new Command("seg-retrieve")
+  .requiredOption("--masks <dir>")
+  .option("--topk <n>", "10")
+  .option("--out <path>", "./tmp/seg_matches.json")
+  .option("--progress <path>", "./tmp/seg-retrieve.progress.json")
+  .action(async (opts) => {
+    requireEmbeddingsProvider();
+    const files = await walk(opts.masks);
+    const progressPath = opts.progress || opts.out;
+    let res:any;
+    try { res = JSON.parse(await fs.readFile(progressPath, "utf8")); } catch { res = {}; }
+    let processed = 0;
+    for (const f of files) {
+      if (res[f]) continue;
+      try {
+        const emb = await withRetry(() => withFallback(p => p.imageEmbed({ path: f })));
+        const hits = await withRetry(() => annSearch(CFG.storage.segmentsTable, "emb_clip_b32", emb, Number(opts.topk)));
+        res[f] = hits;
+        processed++;
+        if (processed % 10 === 0) await fs.writeFile(progressPath, JSON.stringify(res, null, 2));
+      } catch (err:any) {
+        console.warn(`Failed to retrieve for ${f}: ${err?.message || err}`);
+      }
+    }
+    await fs.writeFile(progressPath, JSON.stringify(res, null, 2));
+    if (opts.out !== progressPath) await fs.writeFile(opts.out, JSON.stringify(res, null, 2));
+    console.log(`Wrote ${opts.out}`);
+  });

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
 export const CFG = {
-  storage: { lancedbDir: "./lancedb", recipesTable: "recipes" },
+  storage: { lancedbDir: "./lancedb", recipesTable: "recipes", segmentsTable: "segments" },
   providers: {
     vertex: {
       projectId: process.env.VERTEX_PROJECT_ID || "",

--- a/src/index/lancedb.ts
+++ b/src/index/lancedb.ts
@@ -45,3 +45,20 @@ export async function annSearch(tableName:string, column:string, emb:Float32Arra
   if (filter?.vertical) q = q.where(`vertical = '${filter.vertical}'`);
   return await q.toArray();
 }
+
+export async function upsertSegments(rows:any[]) {
+  const db = await connectDB();
+  let t = await db.openTable(CFG.storage.segmentsTable).catch(()=>null);
+  if (!t) t = await db.createTable(CFG.storage.segmentsTable, rows);
+  else await t.add(rows);
+  return t;
+}
+
+export async function openSegmentsOrThrow() {
+  const db = await connectDB();
+  try {
+    return await db.openTable(CFG.storage.segmentsTable);
+  } catch {
+    throw new Error("segments table not found. Did you run `npx gutty seg-index`?");
+  }
+}

--- a/src/providers/segment.ts
+++ b/src/providers/segment.ts
@@ -1,0 +1,38 @@
+import Replicate from "replicate";
+import fs from "fs/promises";
+import { withRetry } from "../util/retry";
+
+const replicate = new Replicate({ auth: process.env.REPLICATE_API_TOKEN || "" });
+
+function need(key:string){
+  if (!key) throw new Error("REPLICATE_API_TOKEN missing in env");
+}
+
+async function fileOrUrl(input:{path?:string,url?:string}){
+  if (input.url) return input.url as any;
+  if (!input.path) throw new Error("Provide path or url");
+  const buf = await fs.readFile(input.path);
+  return buf as any;
+}
+
+export type Segment = { label: string; mask: Buffer };
+
+export async function groundedSam2(image:{path?:string,url?:string}, prompts:string[]): Promise<Segment[]> {
+  need(replicate.auth as string);
+  const model = process.env.REPLICATE_SEG_MODEL || "nateraw/grounded-sam-2";
+  const out:any = await withRetry(async () =>
+    await replicate.run(model, { input: { image: await fileOrUrl(image), prompts: prompts.join(",") } })
+  );
+  const segs: Segment[] = [];
+  let i = 0;
+  for (const s of out as any[]) {
+    const label = s.label || s.class || `segment${i}`;
+    const b64: string = s.mask || s.mask_png || "";
+    if (!b64) continue;
+    const base = b64.startsWith("data:") ? b64.split(",")[1] : b64;
+    const buf = Buffer.from(base, "base64");
+    segs.push({ label, mask: buf });
+    i++;
+  }
+  return segs;
+}

--- a/src/util/retry.test.ts
+++ b/src/util/retry.test.ts
@@ -1,0 +1,13 @@
+import { withRetry } from './retry';
+import { expect, test } from 'vitest';
+
+test('retries until success', async () => {
+  let attempts = 0;
+  const result = await withRetry(async () => {
+    attempts++;
+    if (attempts < 3) throw new Error('fail');
+    return 'ok';
+  }, 5, 0);
+  expect(result).toBe('ok');
+  expect(attempts).toBe(3);
+});

--- a/src/util/retry.ts
+++ b/src/util/retry.ts
@@ -1,0 +1,14 @@
+export async function withRetry<T>(fn: ()=>Promise<T>, attempts = 3, delayMs = 500): Promise<T> {
+  let lastErr: any;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastErr = err;
+      if (i < attempts - 1) {
+        await new Promise(res => setTimeout(res, delayMs));
+      }
+    }
+  }
+  throw lastErr;
+}


### PR DESCRIPTION
## Summary
- add retries and progress files to segmentation commands
- introduce generic `withRetry` helper and wrap hosted segment calls
- test segmentation flow and ensure CI runs through GitHub Actions

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_6898cc9ca3348333a1d3ada0582c6413