### PR TITLE
Improve density piece handling and add tests

### DIFF
--- a/src/cli/validate.test.ts
+++ b/src/cli/validate.test.ts
@@ -1,0 +1,45 @@
+import path from 'path';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { expect, test, vi } from 'vitest';
+
+const execFileAsync = promisify(execFile);
+
+vi.mock('../providers/availability', () => ({
+  providerSummary: () => ({ hasVertex: true, hasReplicate: false, hasFal: true })
+}));
+
+import fs from 'fs';
+vi.spyOn(fs, 'existsSync').mockImplementation((p: fs.PathLike) => p === './Gutty_Data');
+
+import command from './validate';
+
+test('validate reports provider and filesystem status', async () => {
+  const logs: string[] = [];
+  const logSpy = vi.spyOn(console, 'log').mockImplementation((msg: any) => { logs.push(String(msg)); });
+
+  const prevKey = process.env.FDC_API_KEY;
+  process.env.FDC_API_KEY = 'test';
+
+  await command.parseAsync(['node', 'test'], { from: 'node' });
+
+  const output = logs.join('\n');
+  expect(output).toContain('Vertex:    OK');
+  expect(output).toContain('Replicate: MISSING');
+  expect(output).toContain('Fal:       OK');
+  expect(output).toContain('FDC_API_KEY: OK');
+  expect(output).toContain('./Gutty_Data exists: true');
+  expect(output).toContain('./lancedb exists:  false');
+
+  process.env.FDC_API_KEY = prevKey;
+  logSpy.mockRestore();
+});
+
+test('npx gutty validate --help shows usage', async () => {
+  const { stdout } = await execFileAsync('npx', ['--yes', '--no-install', 'gutty', 'validate', '--help'], {
+    cwd: path.resolve(__dirname, '..', '..'),
+    env: { ...process.env }
+  });
+  expect(stdout).toMatch(/Usage:/);
+});
+

--- a/src/nutrition/density.test.ts
+++ b/src/nutrition/density.test.ts
@@ -1,0 +1,23 @@
+import { computeDensities, toGramsUsingDensity } from './density';
+import { expect, test } from 'vitest';
+
+test('computeDensities aggregates volume and piece data', () => {
+  const food = {
+    foodPortions: [
+      { measureUnit: { name: 'milliliter' }, amount: 1, gramWeight: 1 },
+      { measureUnit: { name: 'milliliter' }, amount: 1, gramWeight: 2 },
+      { measureUnit: { name: 'milliliter' }, amount: 1, gramWeight: 3 },
+      { portionDescription: 'slice, thin', amount: 1, gramWeight: 30 },
+    ],
+  };
+  const dens = computeDensities(food);
+  expect(dens.byVolume.ml).toBeCloseTo(2); // median of [1,2,3]
+  expect(dens.byPiece['slice, thin']).toBeCloseTo(30);
+
+  const gramsVol = toGramsUsingDensity(10, 'ml', dens);
+  expect(gramsVol).toBeCloseTo(20);
+
+  const gramsPiece = toGramsUsingDensity(2, 'slices', dens);
+  expect(gramsPiece).toBeCloseTo(60);
+});
+

--- a/src/nutrition/density.ts
+++ b/src/nutrition/density.ts
@@ -80,8 +80,13 @@ export function toGramsUsingDensity(qty: number, unit: string, dens: DensityResu
       return qty * ML[u] * dens.byVolume[k];
     }
   }
-  const pieceKey = Object.keys(dens.byPiece).find(k => unit.toLowerCase().includes(k.split(" ")[1] || "piece"));
-  if (pieceKey) return qty * dens.byPiece[pieceKey];
+  const unitLc = unit.toLowerCase();
+  for (const [desc, gramsPer] of Object.entries(dens.byPiece)) {
+    const words = desc.toLowerCase().split(/[^a-z]+/).filter(Boolean);
+    if (words.some(w => unitLc.includes(w))) {
+      return qty * gramsPer;
+    }
+  }
   if (u.includes("g")) return qty;
   if (u.includes("kg")) return qty * 1000;
   if (fallbackPer100g) return qty * fallbackPer100g;


### PR DESCRIPTION
## Summary
- refine density conversion to match piece descriptors via word-based search
- add unit tests covering volume and piece conversions
- add CLI tests to exercise `npx gutty validate` with mocked environment and filesystem

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_689de44845fc833396d1b5d27612009b