### PR TITLE
Improve density piece handling and add tests

### DIFF
--- a/src/cli/build-index.test.ts
+++ b/src/cli/build-index.test.ts
@@ -1,0 +1,14 @@
+import { expect, test, vi } from 'vitest';
+
+const { createIndexMock } = vi.hoisted(() => ({
+  createIndexMock: vi.fn(),
+}));
+vi.mock('../index/lancedb', () => ({ createIndex: createIndexMock }));
+
+import command from './build-index';
+
+test('build-index creates HNSW index', async () => {
+  await command.parseAsync(['node', 'test'], { from: 'node' });
+  expect(createIndexMock).toHaveBeenCalledWith('recipes', 'emb_clip_b32');
+});
+

--- a/src/cli/calories.test.ts
+++ b/src/cli/calories.test.ts
@@ -1,0 +1,25 @@
+import path from 'path';
+import os from 'os';
+import { promises as fs } from 'fs';
+import { expect, test, vi } from 'vitest';
+
+const { mapMock, totalMock } = vi.hoisted(() => ({
+  mapMock: vi.fn().mockResolvedValue([{ name: 'x' }]),
+  totalMock: vi.fn().mockReturnValue({ kcal: 1, protein: 2, fat: 3, carbs: 4 }),
+}));
+vi.mock('../nutrition/usda_pipeline', () => ({ mapToUSDA: mapMock, computeTotals: totalMock }));
+
+import command from './calories';
+
+test('calories computes totals and writes file', async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'gutty-'));
+  const recipe = { title:'r', servings:1, ingredients:[{name:'x',qty:1,unit:'g'}] };
+  const recipePath = path.join(tmp, 'r.json');
+  const out = path.join(tmp, 'out.json');
+  await fs.writeFile(recipePath, JSON.stringify(recipe));
+  await command.parseAsync(['node','test','--recipe',recipePath,'--out',out], { from:'node' });
+  expect(mapMock).toHaveBeenCalled();
+  const res = JSON.parse(await fs.readFile(out,'utf8'));
+  expect(res.totals.kcal).toBe(1);
+});
+

--- a/src/cli/health-annotate.test.ts
+++ b/src/cli/health-annotate.test.ts
@@ -1,0 +1,27 @@
+import path from 'path';
+import os from 'os';
+import { promises as fs } from 'fs';
+import { expect, test, vi } from 'vitest';
+
+const { searchMock } = vi.hoisted(() => ({
+  searchMock: vi.fn().mockImplementation(() => ({
+    where: () => ({ limit: () => ({ toArray: async () => [{ id: 'doc' }] }) }),
+  })),
+}));
+vi.mock('../index/lancedb', () => ({ connectDB: async () => ({ openTable: async () => ({ search: searchMock }) }) }));
+vi.mock('../providers/selector', () => ({ withFallback: async (fn: any) => fn({ textEmbed: async () => new Float32Array([1]) }) }));
+
+import command from './health-annotate';
+
+test('health-annotate adds notes and evidence', async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'gutty-'));
+  const recipe = { ingredients:[{name:'shark',qty:1,unit:'fillet'},{name:'sugar',qty:1,unit:'tsp'}] };
+  const recipePath = path.join(tmp, 'r.json');
+  const out = path.join(tmp, 'ann.json');
+  await fs.writeFile(recipePath, JSON.stringify(recipe));
+  await command.parseAsync(['node','test','--recipe',recipePath,'--verticals','pregnancy,pcos','--out',out], { from:'node' });
+  const res = JSON.parse(await fs.readFile(out,'utf8'));
+  expect(res.notes[0].ingredient).toBe('shark');
+  expect(res.evidence.length).toBe(2);
+});
+

--- a/src/cli/health-build-index.test.ts
+++ b/src/cli/health-build-index.test.ts
@@ -1,0 +1,14 @@
+import { expect, test, vi } from 'vitest';
+
+const { createIndexMock } = vi.hoisted(() => ({
+  createIndexMock: vi.fn(),
+}));
+vi.mock('../index/lancedb', () => ({ createIndex: createIndexMock }));
+
+import command from './health-build-index';
+
+test('health-build-index creates index', async () => {
+  await command.parseAsync(['node','test'], { from:'node' });
+  expect(createIndexMock).toHaveBeenCalledWith('health_docs','emb_sbert');
+});
+

--- a/src/cli/health-embed.test.ts
+++ b/src/cli/health-embed.test.ts
@@ -1,0 +1,25 @@
+import { expect, test, vi } from 'vitest';
+
+const { docs, addMock } = vi.hoisted(() => ({
+  docs: [{ id: 'd1', text: 'hello' }],
+  addMock: vi.fn(),
+}));
+vi.mock('../index/lancedb', () => ({
+  connectDB: async () => ({
+    openTable: async () => ({ toArray: async () => docs, add: addMock }),
+  }),
+}));
+vi.mock('../providers/selector', () => ({
+  withFallback: async (fn: any) => fn({ textEmbed: async () => new Float32Array([0.1, 0.2]) }),
+}));
+
+import command from './health-embed';
+
+test('health-embed writes embeddings', async () => {
+  await command.parseAsync(['node', 'test'], { from: 'node' });
+  expect(addMock).toHaveBeenCalledWith(docs, { mode: 'overwrite' });
+  expect(docs[0].emb_sbert).toHaveLength(2);
+  expect(docs[0].emb_sbert[0]).toBeCloseTo(0.1);
+  expect(docs[0].emb_sbert[1]).toBeCloseTo(0.2);
+});
+

--- a/src/cli/health-ingest.test.ts
+++ b/src/cli/health-ingest.test.ts
@@ -1,0 +1,14 @@
+import { expect, test, vi } from 'vitest';
+
+const { ingestMock } = vi.hoisted(() => ({
+  ingestMock: vi.fn().mockResolvedValue(3),
+}));
+vi.mock('../health/ingest', () => ({ ingestHealthKB: ingestMock }));
+
+import command from './health-ingest';
+
+test('health-ingest loads health docs', async () => {
+  await command.parseAsync(['node','test','--dir','/kb'], { from:'node' });
+  expect(ingestMock).toHaveBeenCalledWith('/kb');
+});
+

--- a/src/cli/health-query.test.ts
+++ b/src/cli/health-query.test.ts
@@ -1,0 +1,29 @@
+import path from 'path';
+import os from 'os';
+import { promises as fs } from 'fs';
+import { expect, test, vi } from 'vitest';
+
+const { toArrayMock, limitMock, whereMock, searchMock } = vi.hoisted(() => ({
+  toArrayMock: vi.fn().mockResolvedValue([{ id: 'h1' }]),
+  limitMock: vi.fn().mockImplementation(() => ({ toArray: toArrayMock })),
+  whereMock: vi.fn().mockImplementation(() => ({ limit: limitMock })),
+  searchMock: vi.fn().mockImplementation(() => ({ where: whereMock })),
+}));
+vi.mock('../index/lancedb', () => ({
+  connectDB: async () => ({ openTable: async () => ({ search: searchMock }) }),
+}));
+vi.mock('../providers/selector', () => ({
+  withFallback: async (fn: any) => fn({ textEmbed: async () => new Float32Array([1]) }),
+}));
+
+import command from './health-query';
+
+test('health-query writes hits', async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'gutty-'));
+  const out = path.join(tmp, 'hits.json');
+  await command.parseAsync(['node','test','--vertical','pregnancy','--query','q','--out',out], { from:'node' });
+  expect(searchMock).toHaveBeenCalled();
+  const res = JSON.parse(await fs.readFile(out,'utf8'));
+  expect(res.hits[0].id).toBe('h1');
+});
+

--- a/src/cli/help.test.ts
+++ b/src/cli/help.test.ts
@@ -1,0 +1,21 @@
+import path from 'path';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { expect, test } from 'vitest';
+
+const execFileAsync = promisify(execFile);
+const cmds = [
+  'init','ingest-recipes','embed-recipes','build-index','recipe-retrieve','recipe-rerank','recipe-rag','calories','recipe-analyze',
+  'health-ingest','health-embed','health-build-index','health-query','health-annotate','seg-index','seg-extract','seg-retrieve','validate','reset'
+];
+
+for (const c of cmds) {
+  test(`npx gutty ${c} --help`, async () => {
+    const { stdout } = await execFileAsync('npx', ['--yes','--no-install','gutty', c, '--help'], {
+      cwd: path.resolve(__dirname, '..', '..'),
+      env: { ...process.env }
+    });
+    expect(stdout).toMatch(/Usage:/);
+  });
+}
+

--- a/src/cli/ingest-recipes.test.ts
+++ b/src/cli/ingest-recipes.test.ts
@@ -1,0 +1,14 @@
+import { expect, test, vi } from 'vitest';
+
+const { ingestMock } = vi.hoisted(() => ({
+  ingestMock: vi.fn().mockResolvedValue(2),
+}));
+vi.mock('../recipes/ingest', () => ({ ingestLocalCalData: ingestMock }));
+
+import command from './ingest-recipes';
+
+test('ingest-recipes invokes ingestLocalCalData', async () => {
+  await command.parseAsync(['node', 'test', '--dir', '/data'], { from: 'node' });
+  expect(ingestMock).toHaveBeenCalledWith('/data');
+});
+

--- a/src/cli/init.test.ts
+++ b/src/cli/init.test.ts
@@ -1,0 +1,17 @@
+import path from 'path';
+import os from 'os';
+import { promises as fs } from 'fs';
+import { expect, test } from 'vitest';
+import command from './init';
+
+test('init creates workspace folders', async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'gutty-'));
+  const prev = process.cwd();
+  process.chdir(tmp);
+  await command.parseAsync(['node', 'test'], { from: 'node' });
+  const dirs = await fs.readdir(tmp);
+  expect(dirs).toContain('lancedb');
+  expect(dirs).toContain('tmp');
+  process.chdir(prev);
+});
+

--- a/src/cli/recipe-analyze.test.ts
+++ b/src/cli/recipe-analyze.test.ts
@@ -1,0 +1,45 @@
+import path from 'path';
+import os from 'os';
+import { promises as fs } from 'fs';
+import { expect, test, vi } from 'vitest';
+
+const { annSearchMock, imageEmbedMock, imageEmbedBigMock, visionJSONMock, mapMock, totalsMock } = vi.hoisted(() => ({
+  annSearchMock: vi.fn().mockResolvedValue([
+    { id: 'a', image_paths: ['a.jpg'], title: 'A', ingredients: [], servings: 1 },
+    { id: 'b', image_paths: ['b.jpg'], title: 'B', ingredients: [], servings: 1 },
+  ]),
+  imageEmbedMock: vi.fn().mockResolvedValue(new Float32Array([1, 0])),
+  imageEmbedBigMock: vi
+    .fn()
+    .mockResolvedValueOnce(new Float32Array([1, 0]))
+    .mockResolvedValueOnce(new Float32Array([1, 0]))
+    .mockResolvedValueOnce(new Float32Array([0, 1])),
+  visionJSONMock: vi.fn().mockResolvedValue({
+    chosenRecipeId: 'a',
+    servings: 1,
+    ingredients: [{ name: 'x', qty: 1, unit: 'g' }],
+  }),
+  mapMock: vi.fn().mockResolvedValue([{ name: 'x' }]),
+  totalsMock: vi.fn().mockReturnValue({ kcal: 1, protein: 2, fat: 3, carbs: 4 }),
+}));
+vi.mock('../providers/selector', () => ({
+  withFallback: async (fn: any) => fn({ imageEmbed: imageEmbedMock, imageEmbedBig: imageEmbedBigMock, visionJSON: visionJSONMock }),
+}));
+vi.mock('../index/lancedb', () => ({ annSearch: annSearchMock }));
+vi.mock('../nutrition/usda_pipeline', () => ({ mapToUSDA: mapMock, computeTotals: totalsMock }));
+
+import command from './recipe-analyze';
+
+test('recipe-analyze full pipeline', async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'gutty-'));
+  const out = path.join(tmp, 'analysis.json');
+  await command.parseAsync(['node','test','--image','img.jpg','--out',out,'--topk','2'], { from:'node' });
+  expect(annSearchMock).toHaveBeenCalled();
+  expect(imageEmbedMock).toHaveBeenCalled();
+  expect(imageEmbedBigMock).toHaveBeenCalled();
+  expect(visionJSONMock).toHaveBeenCalled();
+  const res = JSON.parse(await fs.readFile(out,'utf8'));
+  expect(res.recipe.chosenRecipeId).toBe('a');
+  expect(res.totals.kcal).toBe(1);
+});
+

--- a/src/cli/recipe-rag.test.ts
+++ b/src/cli/recipe-rag.test.ts
@@ -1,0 +1,24 @@
+import path from 'path';
+import os from 'os';
+import { promises as fs } from 'fs';
+import { expect, test, vi } from 'vitest';
+
+const { visionMock } = vi.hoisted(() => ({
+  visionMock: vi.fn().mockResolvedValue({ chosenRecipeId: 'a', servings: 1, ingredients: [] }),
+}));
+vi.mock('../providers/selector', () => ({ withFallback: async (fn: any) => fn({ visionJSON: visionMock }) }));
+
+import command from './recipe-rag';
+
+test('recipe-rag writes consolidated recipe', async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'gutty-'));
+  const rankedPath = path.join(tmp, 'rank.json');
+  const out = path.join(tmp, 'recipe.json');
+  const ranked = [{ id:'a', title:'t', ingredients:[], servings:1 }];
+  await fs.writeFile(rankedPath, JSON.stringify({ ranked }, null, 2));
+  await command.parseAsync(['node','test','--image','img.jpg','--candidates',rankedPath,'--out',out], { from:'node' });
+  const res = JSON.parse(await fs.readFile(out,'utf8'));
+  expect(res.chosenRecipeId).toBe('a');
+  expect(visionMock).toHaveBeenCalled();
+});
+

--- a/src/cli/recipe-rerank.test.ts
+++ b/src/cli/recipe-rerank.test.ts
@@ -1,0 +1,29 @@
+import path from 'path';
+import os from 'os';
+import { promises as fs } from 'fs';
+import { expect, test, vi } from 'vitest';
+
+const { embedBig } = vi.hoisted(() => ({
+  embedBig: vi
+    .fn()
+    .mockResolvedValueOnce(new Float32Array([1, 0])) // query
+    .mockResolvedValueOnce(new Float32Array([1, 0])) // cand1
+    .mockResolvedValueOnce(new Float32Array([0, 1])), // cand2
+}));
+vi.mock('../providers/selector', () => ({ withFallback: async (fn: any) => fn({ imageEmbedBig: embedBig }) }));
+
+import command from './recipe-rerank';
+
+test('recipe-rerank rescoring', async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'gutty-'));
+  const candPath = path.join(tmp, 'cand.json');
+  const out = path.join(tmp, 'rank.json');
+  const candidates = [{ id:'a', image_paths:['a.jpg'] }, { id:'b', image_paths:['b.jpg'] }];
+  await fs.writeFile(candPath, JSON.stringify({ candidates }, null, 2));
+  await command.parseAsync(['node','test','--image','img.jpg','--candidates',candPath,'--out',out], { from:'node' });
+  const resText = await fs.readFile(out, 'utf8');
+  const res = JSON.parse(resText);
+  expect(Array.isArray(res.ranked)).toBe(true);
+  expect(embedBig).toHaveBeenCalledTimes(3);
+});
+

--- a/src/cli/recipe-retrieve.test.ts
+++ b/src/cli/recipe-retrieve.test.ts
@@ -1,0 +1,24 @@
+import path from 'path';
+import os from 'os';
+import { promises as fs } from 'fs';
+import { expect, test, vi } from 'vitest';
+
+const { annSearchMock } = vi.hoisted(() => ({
+  annSearchMock: vi.fn().mockResolvedValue([{ id: 'r1' }]),
+}));
+vi.mock('../index/lancedb', () => ({ annSearch: annSearchMock }));
+vi.mock('../providers/selector', () => ({
+  withFallback: async (fn: any) => fn({ imageEmbed: async () => new Float32Array([1,2]) })
+}));
+
+import command from './recipe-retrieve';
+
+test('recipe-retrieve writes candidates file', async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'gutty-'));
+  const out = path.join(tmp, 'cand.json');
+  await command.parseAsync(['node','test','--image','img.jpg','--out',out,'--topk','1'], { from:'node' });
+  expect(annSearchMock).toHaveBeenCalled();
+  const j = JSON.parse(await fs.readFile(out,'utf8'));
+  expect(j.candidates[0].id).toBe('r1');
+});
+

--- a/src/cli/reset.test.ts
+++ b/src/cli/reset.test.ts
@@ -1,0 +1,19 @@
+import path from 'path';
+import os from 'os';
+import { promises as fs } from 'fs';
+import { expect, test } from 'vitest';
+import command from './reset';
+
+test('reset removes lancedb and tmp folders', async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'gutty-'));
+  await fs.mkdir(path.join(tmp, 'lancedb'));
+  await fs.mkdir(path.join(tmp, 'tmp'));
+  const prev = process.cwd();
+  process.chdir(tmp);
+  await command.parseAsync(['node','test'], { from:'node' });
+  const entries = await fs.readdir(tmp);
+  expect(entries).not.toContain('lancedb');
+  expect(entries).not.toContain('tmp');
+  process.chdir(prev);
+});
+

--- a/src/cli/validate.test.ts
+++ b/src/cli/validate.test.ts
@@ -1,0 +1,45 @@
+import path from 'path';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { expect, test, vi } from 'vitest';
+
+const execFileAsync = promisify(execFile);
+
+vi.mock('../providers/availability', () => ({
+  providerSummary: () => ({ hasVertex: true, hasReplicate: false, hasFal: true })
+}));
+
+import fs from 'fs';
+vi.spyOn(fs, 'existsSync').mockImplementation((p: fs.PathLike) => p === './Gutty_Data');
+
+import command from './validate';
+
+test('validate reports provider and filesystem status', async () => {
+  const logs: string[] = [];
+  const logSpy = vi.spyOn(console, 'log').mockImplementation((msg: any) => { logs.push(String(msg)); });
+
+  const prevKey = process.env.FDC_API_KEY;
+  process.env.FDC_API_KEY = 'test';
+
+  await command.parseAsync(['node', 'test'], { from: 'node' });
+
+  const output = logs.join('\n');
+  expect(output).toContain('Vertex:    OK');
+  expect(output).toContain('Replicate: MISSING');
+  expect(output).toContain('Fal:       OK');
+  expect(output).toContain('FDC_API_KEY: OK');
+  expect(output).toContain('./Gutty_Data exists: true');
+  expect(output).toContain('./lancedb exists:  false');
+
+  process.env.FDC_API_KEY = prevKey;
+  logSpy.mockRestore();
+});
+
+test('npx gutty validate --help shows usage', async () => {
+  const { stdout } = await execFileAsync('npx', ['--yes', '--no-install', 'gutty', 'validate', '--help'], {
+    cwd: path.resolve(__dirname, '..', '..'),
+    env: { ...process.env }
+  });
+  expect(stdout).toMatch(/Usage:/);
+});
+

--- a/src/nutrition/density.test.ts
+++ b/src/nutrition/density.test.ts
@@ -1,0 +1,23 @@
+import { computeDensities, toGramsUsingDensity } from './density';
+import { expect, test } from 'vitest';
+
+test('computeDensities aggregates volume and piece data', () => {
+  const food = {
+    foodPortions: [
+      { measureUnit: { name: 'milliliter' }, amount: 1, gramWeight: 1 },
+      { measureUnit: { name: 'milliliter' }, amount: 1, gramWeight: 2 },
+      { measureUnit: { name: 'milliliter' }, amount: 1, gramWeight: 3 },
+      { portionDescription: 'slice, thin', amount: 1, gramWeight: 30 },
+    ],
+  };
+  const dens = computeDensities(food);
+  expect(dens.byVolume.ml).toBeCloseTo(2); // median of [1,2,3]
+  expect(dens.byPiece['slice, thin']).toBeCloseTo(30);
+
+  const gramsVol = toGramsUsingDensity(10, 'ml', dens);
+  expect(gramsVol).toBeCloseTo(20);
+
+  const gramsPiece = toGramsUsingDensity(2, 'slices', dens);
+  expect(gramsPiece).toBeCloseTo(60);
+});
+

--- a/src/nutrition/density.ts
+++ b/src/nutrition/density.ts
@@ -80,8 +80,13 @@ export function toGramsUsingDensity(qty: number, unit: string, dens: DensityResu
       return qty * ML[u] * dens.byVolume[k];
     }
   }
-  const pieceKey = Object.keys(dens.byPiece).find(k => unit.toLowerCase().includes(k.split(" ")[1] || "piece"));
-  if (pieceKey) return qty * dens.byPiece[pieceKey];
+  const unitLc = unit.toLowerCase();
+  for (const [desc, gramsPer] of Object.entries(dens.byPiece)) {
+    const words = desc.toLowerCase().split(/[^a-z]+/).filter(Boolean);
+    if (words.some(w => unitLc.includes(w))) {
+      return qty * gramsPer;
+    }
+  }
   if (u.includes("g")) return qty;
   if (u.includes("kg")) return qty * 1000;
   if (fallbackPer100g) return qty * fallbackPer100g;


### PR DESCRIPTION
## Summary
- refine density conversion to match piece descriptors via word-based search
- add unit tests covering volume and piece conversions
- add CLI tests to exercise `npx gutty validate` with mocked environment and filesystem
- add CLI test coverage for all documented commands including health and pipeline tools

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_689de44845fc833396d1b5d27612009b